### PR TITLE
User Story 3

### DIFF
--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -26,8 +26,14 @@ class BulkDiscountsController < ApplicationController
     else
       flash[:notice] = new_bd.errors.full_messages.join(", ")
       redirect_to new_merchant_bulk_discount_path(merchant)
-      # render :new
+      # render :new <- won't carry the merchant_id
     end
+  end
+
+  def destroy
+    merchant = Merchant.find(params[:merchant_id])
+    merchant.bulk_discounts.find(params[:id]).destroy
+    redirect_to merchant_bulk_discounts_path(merchant)
   end
 
   private

--- a/app/views/bulk_discounts/index.html.erb
+++ b/app/views/bulk_discounts/index.html.erb
@@ -7,6 +7,7 @@
     <p>The <%= bd.title %>:</p>
     <p> <%= (bd.percentage_discount * 100).to_i %>% off <%= bd.quantity_threshold %> of the same item</p>
     <p> <%= link_to  "See More", merchant_bulk_discount_path(bd.merchant_id, bd.id) %></p>
+    <p> <%= link_to  "Delete", merchant_bulk_discount_path(bd.merchant_id, bd.id), method: :delete %></p>
   </div>
   <br>
 <% end %>

--- a/app/views/bulk_discounts/new.html.erb
+++ b/app/views/bulk_discounts/new.html.erb
@@ -5,10 +5,10 @@
   <%= form.text_field :title, required: true %></p>
   <br>
   <%= form.label :percentage_discount, "Discount Precentage:" %>
-  <%= form.number_field :percentage_discount, min: 0, step: 5, max: 99, value: 0, required: true %></p>
+  <%= form.select :percentage_discount, [5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95], required: true %></p>
   <br>
   <%= form.label :quantity_threshold, "Quantity Threshold:" %>
-  <%= form.select :quantity_threshold, [2, 4, 6, 8, 10, 12], required: true %></p>
+  <%= form.number_field :quantity_threshold, min: 0, step: 5, max: 100, value: 0, required: true %></p>
   <br>
   <%= form.submit "Create Discount" %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
     resources :items, except: [:destroy]
     resources :item_status, only: [:update]
     resources :invoices, only: [:index, :show, :update]
-    resources :bulk_discounts, only: [:index, :new, :show, :create]
+    resources :bulk_discounts, only: [:index, :new, :show, :create, :destroy]
   end
 
   namespace :admin do

--- a/spec/features/bulk_discounts/index_spec.rb
+++ b/spec/features/bulk_discounts/index_spec.rb
@@ -48,5 +48,28 @@ RSpec.describe 'merchant/:merchant_id/bulk_discounts', type: :feature do
 
       expect(current_path).to eq(new_merchant_bulk_discount_path(@merchant1.id))
     end
+
+    # User Story 3
+    it "I see a link to delete each bulk discount" do
+      within "#bd-#{@bd_basic.id}" do
+        expect(page).to have_link("Delete", href: "/merchant/#{@merchant1.id}/bulk_discounts/#{@bd_basic.id}")    
+      end
+
+      within "#bd-#{@bd_super.id}" do
+        expect(page).to have_link("Delete", href: "/merchant/#{@merchant1.id}/bulk_discounts/#{@bd_super.id}")
+      end
+    end
+
+    # User Story 3
+    it "when I click on this link, I'm redirected back to this index page & do NOT see the bulk discount" do
+      within "#bd-#{@bd_basic.id}" do
+        click_link("Delete")
+        expect(current_path).to eq(merchant_bulk_discounts_path(@merchant1))
+      end
+
+      expect(page).to_not have_content("The #{@bd_basic.title}:")
+      expect(page).to_not have_content("10% off #{@bd_basic.quantity_threshold} of the same item")
+      expect(page).to_not have_link("See More", href: "/merchant/#{@merchant1.id}/bulk_discounts/#{@bd_basic.id}")    
+    end
   end
 end

--- a/spec/features/bulk_discounts/new_spec.rb
+++ b/spec/features/bulk_discounts/new_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe 'merchant/:merchant_id/bulk_discounts/new', type: :feature do
       click_button("Create Discount")
 
       expect(current_path).to eq( "/merchant/#{@merchant1.id}/bulk_discounts")
+      expect(page).to have_content("Your new bulk discount was successfully created!")
 
       within "#bd-#{@merchant1.bulk_discounts.last.id}" do
         expect(page).to have_content("The Seasonal:")

--- a/spec/features/bulk_discounts/new_spec.rb
+++ b/spec/features/bulk_discounts/new_spec.rb
@@ -20,8 +20,8 @@ RSpec.describe 'merchant/:merchant_id/bulk_discounts/new', type: :feature do
     # User Story 2
     it "when I fill in the form with valid data, I'm redirected to the bd index page & I see my new bd" do
       fill_in("Title", with: "Seasonal")
-      fill_in("Discount Precentage:", with: 20)
-      select(6, from: "Quantity Threshold:")
+      select(85, from: "Discount Precentage:")
+      fill_in("Quantity Threshold:", with: 20)
       click_button("Create Discount")
 
       expect(current_path).to eq( "/merchant/#{@merchant1.id}/bulk_discounts")
@@ -29,7 +29,7 @@ RSpec.describe 'merchant/:merchant_id/bulk_discounts/new', type: :feature do
 
       within "#bd-#{@merchant1.bulk_discounts.last.id}" do
         expect(page).to have_content("The Seasonal:")
-        expect(page).to have_content("20% off 6 of the same item")
+        expect(page).to have_content("85% off 20 of the same item")
         expect(page).to have_link("See More", href: "/merchant/#{@merchant1.id}/bulk_discounts/#{@merchant1.bulk_discounts.first.id}")    
       end
     end
@@ -37,8 +37,8 @@ RSpec.describe 'merchant/:merchant_id/bulk_discounts/new', type: :feature do
     # User Story 2 - Sad Path Test
     it "when I fill in the form with INVALID data, I see an error message" do
       fill_in("Title", with: "")
-      fill_in("Discount Precentage:", with: 5)
-      select(12, from: "Quantity Threshold:")
+      select(5, from: "Discount Precentage:")
+      fill_in("Quantity Threshold:", with: 55)
       click_button("Create Discount")
       expect(current_path).to eq("/merchant/#{@merchant1.id}/bulk_discounts/new")
 


### PR DESCRIPTION
**Completed: Merchant Bulk Discount Delete**
As a merchant
When I visit my bulk discounts index
Then next to each bulk discount I see a link to delete it
When I click this link
Then I am redirected back to the bulk discounts index page
And I no longer see the discount listed