### PR TITLE
User Story 5

### DIFF
--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -5,7 +5,8 @@ class BulkDiscountsController < ApplicationController
   end
 
   def show
-    @bulk_discount = BulkDiscount.find(params[:id])
+    @merchant = Merchant.find(params[:merchant_id])
+    @bulk_discount = @merchant.bulk_discounts.find(params[:id])
   end
 
   def new
@@ -14,10 +15,8 @@ class BulkDiscountsController < ApplicationController
 
   def create
     merchant = Merchant.find(params[:merchant_id])
-
     new_params = bulk_discount_params
     new_params[:percentage_discount] = (new_params[:percentage_discount].to_f/100)
-
     new_bd = merchant.bulk_discounts.new(new_params)
    
     if new_bd.save
@@ -29,6 +28,15 @@ class BulkDiscountsController < ApplicationController
       # render :new <- won't carry the merchant_id
     end
   end
+
+  def edit
+    @merchant = Merchant.find(params[:merchant_id])
+    @bulk_discount = @merchant.bulk_discounts.find(params[:id])
+    # @bulk_discount = BulkDiscount.find(params[:id])
+  end
+
+  # def update
+  # end
 
   def destroy
     merchant = Merchant.find(params[:merchant_id])

--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -32,6 +32,7 @@ class BulkDiscountsController < ApplicationController
   def edit
     @merchant = Merchant.find(params[:merchant_id])
     @bulk_discount = @merchant.bulk_discounts.find(params[:id])
+    @discount_number = ((@bulk_discount.percentage_discount)*100).to_i
     # @bulk_discount = BulkDiscount.find(params[:id])
   end
 

--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -33,11 +33,23 @@ class BulkDiscountsController < ApplicationController
     @merchant = Merchant.find(params[:merchant_id])
     @bulk_discount = @merchant.bulk_discounts.find(params[:id])
     @discount_number = ((@bulk_discount.percentage_discount)*100).to_i
-    # @bulk_discount = BulkDiscount.find(params[:id])
   end
 
-  # def update
-  # end
+  def update
+    merchant = Merchant.find(params[:merchant_id])
+    bulk_discount = BulkDiscount.find(params[:id])
+    new_params = bulk_discount_params
+    new_params[:percentage_discount] = (new_params[:percentage_discount].to_f/100)
+ 
+    if bulk_discount.update!(new_params)
+      flash[:success] = "Your bulk discount was successfully edited!"
+      redirect_to merchant_bulk_discount_path(merchant, bulk_discount)
+    else
+      # Not sure if this is necessary since all fields are required & it'll never allow errors??
+      flash[:notice] = new_bd.errors.full_messages.join(", ")
+      redirect_to edit_merchant_bulk_discount_path(merchant, bulk_discount)
+    end
+  end
 
   def destroy
     merchant = Merchant.find(params[:merchant_id])

--- a/app/views/bulk_discounts/edit.html.erb
+++ b/app/views/bulk_discounts/edit.html.erb
@@ -1,0 +1,14 @@
+<h1>Edit Bulk Discount</h1>
+<br>
+<%= form_with url: merchant_bulk_discount_path(@merchant, @bulk_discount), method: :patch, local: true do |form| %>
+  <p><%= form.label :title, "Title" %>
+  <%= form.text_field :title, value: @bulk_discount.title, required: true %></p>
+  <br>
+  <%= form.label :percentage_discount, "Discount Precentage:" %>
+  <%= form.select :percentage_discount, [5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95], selected: @discount_number, required: true %></p>
+  <br>
+  <%= form.label :quantity_threshold, "Quantity Threshold:" %>
+  <%= form.number_field :quantity_threshold, min: 0, step: 1, max: 100, value: @bulk_discount.quantity_threshold, required: true %></p>
+  <br>
+  <%= form.submit "Submit" %>
+<% end %>

--- a/app/views/bulk_discounts/new.html.erb
+++ b/app/views/bulk_discounts/new.html.erb
@@ -8,7 +8,7 @@
   <%= form.select :percentage_discount, [5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95], required: true %></p>
   <br>
   <%= form.label :quantity_threshold, "Quantity Threshold:" %>
-  <%= form.number_field :quantity_threshold, min: 0, step: 5, max: 100, value: 0, required: true %></p>
+  <%= form.number_field :quantity_threshold, min: 0, step: 1, max: 100, value: 0, required: true %></p>
   <br>
   <%= form.submit "Create Discount" %>
 <% end %>

--- a/app/views/bulk_discounts/show.html.erb
+++ b/app/views/bulk_discounts/show.html.erb
@@ -2,3 +2,5 @@
 <br>
 <p>Precentage Discount (as a decimal): <%= @bulk_discount.percentage_discount %></p>
 <p>Quantity Threshold (for same item): <%= @bulk_discount.quantity_threshold %></p>
+<br>
+<p> <%= link_to "Update this Bulk Discount", edit_merchant_bulk_discount_path(@merchant, @bulk_discount) %></p>

--- a/app/views/bulk_discounts/show.html.erb
+++ b/app/views/bulk_discounts/show.html.erb
@@ -3,4 +3,4 @@
 <p>Precentage Discount (as a decimal): <%= @bulk_discount.percentage_discount %></p>
 <p>Quantity Threshold (for same item): <%= @bulk_discount.quantity_threshold %></p>
 <br>
-<p> <%= link_to "Update this Bulk Discount", edit_merchant_bulk_discount_path(@merchant, @bulk_discount) %></p>
+<p> <%= link_to "Edit this Bulk Discount", edit_merchant_bulk_discount_path(@merchant, @bulk_discount) %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
     resources :items, except: [:destroy]
     resources :item_status, only: [:update]
     resources :invoices, only: [:index, :show, :update]
-    resources :bulk_discounts, only: [:index, :new, :show, :create, :destroy]
+    resources :bulk_discounts, except: [:put]
   end
 
   namespace :admin do

--- a/spec/features/bulk_discounts/edit_spec.rb
+++ b/spec/features/bulk_discounts/edit_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe 'merchant/:merchant_id/bulk_discounts/:bulk_discount_id/edit', type: :feature do
+  before :each do 
+    @merchant1 = Merchant.create!(name: 'The Frisbee Store')
+
+    @bd_basic = @merchant1.bulk_discounts.create!(title: "Basic", percentage_discount: 0.1, quantity_threshold: 2)
+
+    visit edit_merchant_bulk_discount_path(@merchant1, @bd_basic)
+  end
+  
+  context "As a merchant, when I visit the bulk discounts edit page" do
+    # User Story 5
+    it "I see a form to edit the bulk discount with pre-populated attributes visible in the form fields" do 
+      expect(page).to have_content("Edit Bulk Discount")
+      expect(page).to have_field(:title, :with => "Basic")
+      expect(page).to have_field(:percentage_discount, :with => 10)
+      expect(page).to have_field(:quantity_threshold, :with => 2)
+      expect(page).to have_button("Submit")
+    end
+
+    # User Story 5  
+    xit "when I change any/all of the info & click submit, I'm redirected to it's show page & see the updated info" do
+    end
+  end
+end

--- a/spec/features/bulk_discounts/edit_spec.rb
+++ b/spec/features/bulk_discounts/edit_spec.rb
@@ -20,7 +20,30 @@ RSpec.describe 'merchant/:merchant_id/bulk_discounts/:bulk_discount_id/edit', ty
     end
 
     # User Story 5  
-    xit "when I change any/all of the info & click submit, I'm redirected to it's show page & see the updated info" do
+    it "when I change any/all of the info & click submit, I'm redirected to it's show page & see the updated info" do
+      fill_in("Title", with: "Better Basic")
+      select(20, from: "Discount Precentage:")
+      fill_in("Quantity Threshold:", with: 2)
+      click_button("Submit")
+  
+      expect(current_path).to eq( "/merchant/#{@merchant1.id}/bulk_discounts/#{@bd_basic.id}")
+      expect(page).to have_content("Your bulk discount was successfully edited!")
+
+      expect(page).to have_content("Details for Bulk Discount: Better Basic")
+      expect(page).to have_content("Precentage Discount (as a decimal): 0.2")
+      expect(page).to have_content("Quantity Threshold (for same item): 2")
     end
+
+    # User Story 5 - Sad Path 
+    # Cant seem to test this since all fields are required
+    # it "when I change any/all of the info INCORRECTLY & click submit, I see an error message" do
+    #   fill_in("Title", with: "")
+    #   select(10, from: "Discount Precentage:")
+    #   fill_in("Quantity Threshold:", with: 2)
+    #   click_button("Submit")
+
+    #   expect(current_path).to eq( "/merchant/#{@merchant1.id}/bulk_discounts/#{@bd_basic.id}/edit")
+    #   expect(page).to have_content("ERROR MESSAGE HERE")
+    # end
   end
 end

--- a/spec/features/bulk_discounts/new_spec.rb
+++ b/spec/features/bulk_discounts/new_spec.rb
@@ -40,8 +40,8 @@ RSpec.describe 'merchant/:merchant_id/bulk_discounts/new', type: :feature do
       select(5, from: "Discount Precentage:")
       fill_in("Quantity Threshold:", with: 55)
       click_button("Create Discount")
+      
       expect(current_path).to eq("/merchant/#{@merchant1.id}/bulk_discounts/new")
-
       expect(page).to have_content("Title can't be blank")
     end
   end

--- a/spec/features/bulk_discounts/show_spec.rb
+++ b/spec/features/bulk_discounts/show_spec.rb
@@ -16,5 +16,17 @@ RSpec.describe 'merchant/:merchant_id/bulk_discounts/:bulk_discount_id', type: :
       expect(page).to have_content("Precentage Discount (as a decimal): #{@bd_basic.percentage_discount}")
       expect(page).to have_content("Quantity Threshold (for same item): #{@bd_basic.quantity_threshold}")
     end
+
+    # User Story 5
+    it "I see a link to edit the bulk discount" do
+      expect(page).to have_link("Update this Bulk Discount", href: "/merchant/#{@merchant1.id}/bulk_discounts/#{@bd_basic.id}/edit")
+    end
+
+    # User Story 5
+    it "when I click on this link & am taken to that bulk discount's edit page" do
+      click_link("Update this Bulk Discount")
+      expect(current_path).to eq(edit_merchant_bulk_discount_path(@merchant1, @bd_basic))
+    end
+    
   end
 end

--- a/spec/features/bulk_discounts/show_spec.rb
+++ b/spec/features/bulk_discounts/show_spec.rb
@@ -19,14 +19,13 @@ RSpec.describe 'merchant/:merchant_id/bulk_discounts/:bulk_discount_id', type: :
 
     # User Story 5
     it "I see a link to edit the bulk discount" do
-      expect(page).to have_link("Update this Bulk Discount", href: "/merchant/#{@merchant1.id}/bulk_discounts/#{@bd_basic.id}/edit")
+      expect(page).to have_link("Edit this Bulk Discount", href: "/merchant/#{@merchant1.id}/bulk_discounts/#{@bd_basic.id}/edit")
     end
 
     # User Story 5
     it "when I click on this link & am taken to that bulk discount's edit page" do
-      click_link("Update this Bulk Discount")
+      click_link("Edit this Bulk Discount")
       expect(current_path).to eq(edit_merchant_bulk_discount_path(@merchant1, @bd_basic))
     end
-    
   end
 end


### PR DESCRIPTION
**Completed: Merchant Bulk Discount Edit**
As a merchant
When I visit my bulk discount show page
Then I see a link to edit the bulk discount
When I click this link
Then I am taken to a new page with a form to edit the discount
And I see that the discounts current attributes are pre-poluated in the form
When I change any/all of the information and click submit
Then I am redirected to the bulk discount's show page
And I see that the discount's attributes have been updated